### PR TITLE
feat(breadcrumb)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "js-cookie": "^3.0.1",
         "lodash": "^4.17.21",
         "nprogress": "^0.2.0",
+        "path-to-regexp": "^1.8.0",
         "vue": "^2.6.11",
         "vue-class-component": "^7.2.3",
         "vue-property-decorator": "^9.1.2",
@@ -7961,6 +7962,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/express/node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "dev": true
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmmirror.com/extend/-/extend-3.0.2.tgz",
@@ -12681,11 +12688,17 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmmirror.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
+    "node_modules/path-to-regexp/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -23554,6 +23567,12 @@
           "resolved": "https://registry.npmmirror.com/ms/-/ms-2.0.0.tgz",
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+          "dev": true
         }
       }
     },
@@ -26970,10 +26989,19 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmmirror.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
-      "dev": true
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
+      }
     },
     "path-type": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "js-cookie": "^3.0.1",
     "lodash": "^4.17.21",
     "nprogress": "^0.2.0",
+    "path-to-regexp": "^1.8.0",
     "vue": "^2.6.11",
     "vue-class-component": "^7.2.3",
     "vue-property-decorator": "^9.1.2",

--- a/src/assets/layout/index.scss
+++ b/src/assets/layout/index.scss
@@ -1,3 +1,4 @@
+@import '~element-ui/packages/theme-chalk/src/common/var.scss';
 @import './variables.scss';
 
 .layout-wrapper {
@@ -21,6 +22,20 @@
   width: 100%;
   height: 48px;
   line-height: 48px;
+}
+
+.layout-container .el-breadcrumb {
+  padding: 16px 0 16px 24px;
+  background-color: #fff;
+  box-shadow: $--box-shadow-light;
+
+  &:empty {
+    display: none;
+  }
+
+  .is-link {
+    font-weight: normal;
+  }
 }
 
 .layout-main-content {

--- a/src/components/Placeholder.vue
+++ b/src/components/Placeholder.vue
@@ -1,0 +1,12 @@
+<template>
+  <p>{{ cname }} works!</p>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+
+@Component({ name: 'Placeholder' })
+export default class Placeholder extends Vue {
+  @Prop() cname!: string;
+}
+</script>

--- a/src/layout/components/Sider.vue
+++ b/src/layout/components/Sider.vue
@@ -1,7 +1,7 @@
 <template>
   <aside class="layout-sider layout-sider-fixed" :class="collapseClass">
     <div class="layout-sider-menu">
-      <ElMenu default-active="2" :collapse="collapse" class="el-menu-sider">
+      <ElMenu default-active="2" :collapse="collapse" class="el-menu-sider" router>
         <ElSubmenu index="1">
           <template slot="title">
             <i class="el-icon-setting"></i>
@@ -18,6 +18,24 @@
           <i class="el-icon-bell"></i>
           <span slot="title">通知公告</span>
         </ElMenuItem>
+        <ElSubmenu index="auth">
+          <template #title>
+            <i class="el-icon-lock"></i>
+            <span>权限管理</span>
+          </template>
+          <ElMenuItem index="/auth/roles">角色管理</ElMenuItem>
+          <ElMenuItem index="/auth/roles/create">创建角色</ElMenuItem>
+        </ElSubmenu>
+        <ElSubmenu index="class">
+          <template #title>
+            <i class="el-icon-user"></i>
+            <span>班级管理</span>
+          </template>
+          <ElMenuItem index="/class/students/">学生管理</ElMenuItem>
+          <ElMenuItem index="/class/teachers/">教师管理</ElMenuItem>
+          <ElMenuItem index="/class/teachers/57">57 号教师</ElMenuItem>
+          <ElMenuItem index="/class/teachers/57/hobbies">57 号教师的爱好</ElMenuItem>
+        </ElSubmenu>
       </ElMenu>
     </div>
     <div @click="onCollapseChange" class="collapse-sider-menu">

--- a/src/layout/index.vue
+++ b/src/layout/index.vue
@@ -5,6 +5,15 @@
     <div class="layout-container">
       <header class="layout-header-placeholder"></header>
       <Header />
+      <ElBreadcrumb>
+        <ElBreadcrumbItem
+          v-for="(breadcrumb, index) in breadcrumbItems"
+          :key="index"
+          :to="index === breadcrumbItems.length - 1 ? undefined : breadcrumb.url"
+        >
+          {{ breadcrumb.title }}
+        </ElBreadcrumbItem>
+      </ElBreadcrumb>
       <main class="layout-main-content">
         <router-view></router-view>
       </main>
@@ -15,8 +24,16 @@
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator';
 import { Getter } from 'vuex-class';
+import pathToRegexp from 'path-to-regexp';
+
+import { EvRouteConfig } from '@/router';
 import Sider from './components/Sider.vue';
 import Header from './components/Header.vue';
+
+type EvBreadcrumbItem = {
+  title: string;
+  url?: string;
+};
 
 @Component({
   name: 'Layout',
@@ -31,6 +48,40 @@ export default class Layout extends Vue {
 
   get collapseClass() {
     return { 'layout-sider-collapsed': this.collapse };
+  }
+
+  get breadcrumbItems() {
+    const { $route } = this;
+    const { params, matched } = $route;
+    const breadcrumb = ($route.meta as EvRouteConfig['meta'])?.breadcrumb;
+    let breadcrumbs: EvBreadcrumbItem[] = [];
+    if (Array.isArray(breadcrumb)) {
+      breadcrumbs = breadcrumb.map(x => {
+        if (typeof x === 'string') {
+          return { title: x };
+        }
+        return x;
+      });
+    } else if (breadcrumb !== false) {
+      breadcrumbs = matched
+        .map(matched => {
+          const matchedBreadcrumb = matched?.meta?.breadcrumb;
+
+          const breadcrumbItem: EvBreadcrumbItem = {
+            title: matchedBreadcrumb?.title,
+          };
+          if (matchedBreadcrumb?.navigatable !== false) {
+            const toPath = pathToRegexp.compile(matched.path);
+            const matchedUrl = toPath(params);
+            breadcrumbItem.url = matchedUrl;
+          }
+
+          return breadcrumbItem;
+        })
+        .filter(x => typeof x.title !== 'undefined');
+    }
+
+    return breadcrumbs;
   }
 }
 </script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -7,6 +7,7 @@ import { cloneDeep, omit } from 'lodash';
 
 import Dashboard from '@/views/index.vue';
 import Layout from '@/layout/index.vue';
+import Placeholder from '@/components/Placeholder.vue';
 
 Vue.use(VueRouter);
 
@@ -42,6 +43,105 @@ const routes: Array<EvRouteConfig> = [
         name: 'Dashboard',
         component: Dashboard,
       },
+      //#region fake routes
+      // fake flatted routes
+      {
+        path: 'auth/roles',
+        name: 'RoleManage',
+        component: Placeholder,
+        props: {
+          cname: 'role-manage',
+        },
+        meta: {
+          breadcrumb: [{ title: '权限管理' }, { title: '角色管理' }],
+        },
+      },
+      {
+        path: 'auth/roles/create',
+        name: 'RoleCreate',
+        component: Placeholder,
+        props: {
+          cname: 'role-create',
+        },
+        meta: {
+          breadcrumb: [{ title: '权限管理' }, { title: '角色管理' }, { title: '创建角色' }],
+        },
+      },
+      // fake nested routes
+      {
+        path: 'class',
+        meta: {
+          breadcrumb: { title: '班级管理', navigatable: false },
+        },
+        children: [
+          {
+            path: 'students',
+            meta: {
+              breadcrumb: { title: '学生管理' },
+            },
+            children: [
+              {
+                path: '',
+                name: 'StudentManage',
+                component: Placeholder,
+                props: {
+                  cname: 'student-manage',
+                },
+              },
+            ],
+          },
+          {
+            path: 'teachers',
+            meta: {
+              breadcrumb: { title: '教师管理', navigatable: false },
+            },
+            children: [
+              {
+                path: '',
+                name: 'TeacherManage',
+                component: Placeholder,
+                props: {
+                  cname: 'teacher-manage',
+                },
+                meta: {
+                  breadcrumb: { title: '教师列表' },
+                },
+              },
+              {
+                path: ':id',
+                meta: {
+                  breadcrumb: { title: '教师详情' },
+                },
+                children: [
+                  {
+                    path: '',
+                    name: 'TeacherView',
+                    component: Placeholder,
+                    props: route => ({
+                      cname: `teacher-${route.params.id}`,
+                    }),
+                    meta: {
+                      breadcrumb: false,
+                    },
+                  },
+                  {
+                    path: 'hobbies',
+                    name: 'TeacherHobbiesView',
+                    component: Placeholder,
+                    props: route => ({
+                      cname: `teacher-${route.params.id}'s-hobbies`,
+                    }),
+                    meta: {
+                      breadcrumb: { title: '教师爱好' },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      //#endregion
     ],
   },
 ];

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import type { ComponentOptions } from 'vue';
 import VueRouter from 'vue-router';
-import type { RouteConfig } from 'vue-router';
+import type { RouteConfig, RouteMeta } from 'vue-router';
 import type { RouteConfigSingleView, RouteConfigMultipleViews } from 'vue-router/types/router';
 import { cloneDeep, omit } from 'lodash';
 
@@ -10,7 +10,29 @@ import Layout from '@/layout/index.vue';
 
 Vue.use(VueRouter);
 
-const routes: Array<RouteConfig> = [
+/**
+ * 面包屑配置，支持false, 对象和数组形式配置：
+ *
+ * `false`: 命中路由时不展示面包屑，请注意有/无面包屑的页面切换时可能造成页面抖动。
+ *
+ * 对象(`{ title: string; navigatable?: false }`)：命中路由时由顶级路由配置开始寻找，依次展示所有找到的面包屑，`navigatable`为 false 时这一层面包屑不能跳转；**支持包含参数的path 跳转**。
+ *
+ * 数组(`string | { title: string; url?: string}`)：命中路由时直接展示指定的面包屑，传入字符串时会被转换为`{ title }`；url 为空时生成的面包屑不能跳转。
+ *
+ * TODO: Standard document format
+ */
+type MetaBreadcrumb = false | { title: string; navigatable?: false } | (string | { title: string; url?: string })[];
+
+/**
+ * Elev 扩展的路由定义
+ */
+export type EvRouteConfig = RouteConfig & {
+  meta?: RouteMeta & {
+    breadcrumb?: MetaBreadcrumb;
+  };
+};
+
+const routes: Array<EvRouteConfig> = [
   {
     path: '/',
     component: Layout,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,5 +1,10 @@
 import Vue from 'vue';
-import VueRouter, { RouteConfig } from 'vue-router';
+import type { ComponentOptions } from 'vue';
+import VueRouter from 'vue-router';
+import type { RouteConfig } from 'vue-router';
+import type { RouteConfigSingleView, RouteConfigMultipleViews } from 'vue-router/types/router';
+import { cloneDeep, omit } from 'lodash';
+
 import Dashboard from '@/views/index.vue';
 import Layout from '@/layout/index.vue';
 
@@ -19,10 +24,48 @@ const routes: Array<RouteConfig> = [
   },
 ];
 
+const PassThroughComponent: ComponentOptions<Vue> = {
+  render: h => h('router-view'),
+};
+
+/**
+ * @see {@link addPassThroughComponent}
+ */
+export function addPassThroughComponents(routes: RouteConfig[]): RouteConfig[] {
+  return routes.map(route => {
+    const cloned: RouteConfig = cloneDeep(omit(route, 'children'));
+    if (Array.isArray(route.children)) {
+      cloned.children = [];
+      addPassThroughComponent(cloned);
+      cloned.children = addPassThroughComponents(route.children);
+    }
+
+    return cloned;
+  });
+}
+
+/**
+ * 为有children 无component （我们称为logic group，逻辑组）路由设置默认的Component。
+ *
+ * @param route 路由配置
+ * @returns [mutated] 设置了默认Component 的路由配置
+ */
+export function addPassThroughComponent(route: RouteConfig): RouteConfig {
+  if (
+    Array.isArray(route.children) &&
+    typeof (route as RouteConfigMultipleViews).components === 'undefined' &&
+    typeof (route as RouteConfigSingleView).component === 'undefined'
+  ) {
+    (route as RouteConfigSingleView).component = PassThroughComponent;
+  }
+
+  return route;
+}
+
 const router = new VueRouter({
   mode: 'history',
   base: process.env.BASE_URL,
-  routes,
+  routes: addPassThroughComponents(routes),
 });
 
 export default router;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5642,6 +5642,11 @@
   "resolved" "https://registry.npmmirror.com/isarray/-/isarray-1.0.0.tgz"
   "version" "1.0.0"
 
+"isarray@0.0.1":
+  "integrity" "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+  "resolved" "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+  "version" "0.0.1"
+
 "isexe@^2.0.0":
   "integrity" "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
   "resolved" "https://registry.npmmirror.com/isexe/-/isexe-2.0.0.tgz"
@@ -6954,9 +6959,16 @@
   "resolved" "https://registry.npmmirror.com/path-parse/-/path-parse-1.0.7.tgz"
   "version" "1.0.7"
 
+"path-to-regexp@^1.8.0":
+  "integrity" "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA=="
+  "resolved" "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz"
+  "version" "1.8.0"
+  dependencies:
+    "isarray" "0.0.1"
+
 "path-to-regexp@0.1.7":
-  "integrity" "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
-  "resolved" "https://registry.npmmirror.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+  "integrity" "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+  "resolved" "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
   "version" "0.1.7"
 
 "path-type@^3.0.0":


### PR DESCRIPTION
支持逻辑分组路由（即父级路由无容器，直接渲染到上级容器中）

展示命中路由的面包屑

添加EvRouteConfig 类型，扩展路由配置字段。

Add fake routes